### PR TITLE
BUGFIX[hotfix]: Border Radius not set

### DIFF
--- a/src/helpers/applystyles.ts
+++ b/src/helpers/applystyles.ts
@@ -7,7 +7,7 @@
 async function applystyles(node: HTMLElement, cloned: HTMLElement): Promise<void> {
 	await Promise.resolve();
 	const styles = window.getComputedStyle(node);
-	Object.keys(styles).map((val: any) => {
+	Object.values(styles).map((val: any) => {
 		cloned.style.setProperty(val, styles.getPropertyValue(val), styles.getPropertyPriority(val));
 	});
 }


### PR DESCRIPTION
Apparently border-radius is not set for svg elements because in the DOM element itself,
`...styles.getPropertyValue("borderRadius")` is set to 0px (even when the element has a border radius). Had to set `border-radius` property as a hotfix until a cleaner solution is found.